### PR TITLE
OCPBUGS-39505: UPSTREAM: <carry>: Updating ose-azure-storage-azcopy-base-container i…

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 WORKDIR /go/src/github.com/openshift/azure-storage-azcopy
 COPY . .
 RUN go build -o ./bin/azcopy .
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/azure-storage-azcopy/bin/azcopy /usr/bin/


### PR DESCRIPTION
…mage to be consistent with ART for 4.18

Reconciling with https://github.com/openshift/ocp-build-data/tree/827ab4ccce9cbbcf82c9dbaf6398b61d6cff8d7a/images/ose-azure-storage-azcopy-base.yml

Reconciling manually to add `UPSTREAM: <carry>:`, ART toolchain was not configured to add it automatically.

cc @openshift/storage 